### PR TITLE
End of Module-based approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ compile_commands.json
 *.old
 *.ninja
 Makefile
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bro
 compile_commands.json
 *.old
+*.ninja

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bro
 compile_commands.json
 *.old
 *.ninja
+Makefile

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 YetAnotherFurryMan
+Copyright (c) 2023 Damian Satoła
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Simply create a file `bro.cpp`, include there `bro.hpp`, describe your project (
 - [x] Run commands (sync/async)
 - [x] Command pools and queues
 - [x] Build a modular project
-- [ ] Build a project where modules depends on each other
-- [ ] Build a project where modules depends on external modules (np. local libraries)
+- [x] Build a project where modules depends on each other
+- [x] Build a project where modules depends on external modules (np. local libraries)
 - [ ] Download external dependencies from git(hub)
 - [ ] App+engine project model
-- [ ] Command-line flags
-- [ ] Choose between clang and gcc via flags
+- [x] Command-line flags
+- [x] Choose between clang and gcc via flags

--- a/bro.cpp
+++ b/bro.cpp
@@ -9,6 +9,8 @@ int main(int argc, const char** argv){
 	
 	bro.fresh();
 
+	bro.log.info("Header: {}", bro.header);
+
 	bro.registerCmd("g++", ".cpp", {"g++", "-c", "$in", "-o", "$out"});
 	bro.registerCmd("gcc", ".c", {"gcc", "-c", "$in", "-o", "$out"});
 

--- a/bro.cpp
+++ b/bro.cpp
@@ -74,7 +74,7 @@ int main(int argc, const char** argv){
 
 	bro.ninja();
 
-	if(bro.flags.find("save") == bro.flags.end()){
+	if(bro.isFlagSet("save")){
 		std::filesystem::remove_all("src");
 		std::filesystem::remove_all("build");
 	}

--- a/bro.cpp
+++ b/bro.cpp
@@ -12,8 +12,8 @@ int main(int argc, const char** argv){
 
 	bro.log.info("Header: {}", bro.header);
 
-	bro.registerCmd("cxx", ".cpp", {"g++", "-c", "$in", "-o", "$out"});
-	bro.registerCmd("cc", ".c", {"gcc", "-c", "$in", "-o", "$out"});
+	bro.registerCmd("cxx", ".cpp", ".cpp.o", {"g++", "-c", "$in", "-o", "$out"});
+	bro.registerCmd("cc", ".c", ".c.o", {"gcc", "-c", "$in", "-o", "$out"});
 
 	bro::CmdTmpl run({"./$in"});
 

--- a/bro.cpp
+++ b/bro.cpp
@@ -73,8 +73,9 @@ int main(int argc, const char** argv){
 	}
 
 	bro.ninja();
+	bro.makefile();
 
-	if(bro.isFlagSet("save")){
+	if(!bro.isFlagSet("save")){
 		std::filesystem::remove_all("src");
 		std::filesystem::remove_all("build");
 	}

--- a/bro.cpp
+++ b/bro.cpp
@@ -11,8 +11,8 @@ int main(int argc, const char** argv){
 
 	bro.log.info("Header: {}", bro.header);
 
-	bro.registerCmd("g++", ".cpp", {"g++", "-c", "$in", "-o", "$out"});
-	bro.registerCmd("gcc", ".c", {"gcc", "-c", "$in", "-o", "$out"});
+	bro.registerCmd("cxx", ".cpp", {"g++", "-c", "$in", "-o", "$out"});
+	bro.registerCmd("cc", ".c", {"gcc", "-c", "$in", "-o", "$out"});
 
 	bro::CmdTmpl run({"./$in"});
 
@@ -20,7 +20,7 @@ int main(int argc, const char** argv){
 	bro::Directory mod("src/mod");
 
 	bro.registerModule(bro::ModType::EXE, "mod");
-	bro.use("mod", "g++");
+	bro.use("mod", "cxx");
 	bro.link("mod", "-lstdc++");
 
 	{
@@ -67,13 +67,17 @@ int main(int argc, const char** argv){
 		mod_bye << "#include <stdio.h>\nvoid bye(){printf(\"Hello from bye()\\n\");}";
 		mod_bye.close();
 
-		bro.use("mod", "gcc");
+		bro.use("mod", "cc");
 		bro.build();
 		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
 	}
 
-	std::filesystem::remove_all("src");
-	std::filesystem::remove_all("build");
+	bro.ninja();
+
+	if(bro.flags.find("save") == bro.flags.end()){
+		std::filesystem::remove_all("src");
+		std::filesystem::remove_all("build");
+	}
 
 	bro.log.info("Cmds: {}", bro.cmds.size());
 	for(const auto& [key, val]: bro.cmds){

--- a/bro.cpp
+++ b/bro.cpp
@@ -33,7 +33,7 @@ int main(int argc, const char** argv){
 		mod_hello << "#include <iostream>\nvoid hello(){std::cout << \"Hello from hello()\" << std::endl;}";
 		mod_hello.close();
 
-		bro.build();
+		bro.run();
 
 		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
 	}
@@ -47,13 +47,13 @@ int main(int argc, const char** argv){
 		mod_bye << "#include <iostream>\nvoid bye(){std::cout << \"Hello from bye()\" << std::endl;}";
 		mod_bye.close();
 
-		bro.build();
+		bro.run();
 
 		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
 	}
 
 	{
-		bro.build();
+		bro.run();
 		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
 	}
 
@@ -69,7 +69,7 @@ int main(int argc, const char** argv){
 		mod_bye.close();
 
 		bro.use("mod", "cc");
-		bro.build();
+		bro.run();
 		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
 	}
 

--- a/bro.cpp
+++ b/bro.cpp
@@ -19,6 +19,7 @@ int main(int argc, const char** argv){
 
 	bro.registerModule(bro::ModType::EXE, "mod");
 	bro.use("mod", "g++");
+	bro.link("mod", "-lstdc++");
 
 	{
 		std::ofstream mod_main("src/mod/main.cpp");

--- a/bro.cpp
+++ b/bro.cpp
@@ -6,6 +6,7 @@ int main(int argc, const char** argv){
 	bro::Bro bro(argc, argv);
 	
 	bro.log.info("Fresh: {}", bro.isFresh());
+	bro.log.info("Has ~FRESH: {}", bro.hasFlag("~FRESH"));
 	
 	bro.fresh();
 

--- a/bro.cpp
+++ b/bro.cpp
@@ -73,12 +73,31 @@ int main(int argc, const char** argv){
 		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
 	}
 
-	bro.ninja();
-	bro.makefile();
+	{
+		std::filesystem::remove_all("build");
+		bro.ninja();
+
+		bro::CmdTmpl ninja({"ninja"});
+		ninja.sync(bro.log);
+		
+		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
+	}
+
+	{
+		std::filesystem::remove_all("build");
+		bro.makefile();
+
+		bro::CmdTmpl make({"make"});
+		make.sync(bro.log);
+		
+		run.sync(bro.log, {{"in", {"build/bin/mod"}}});
+	}
 
 	if(!bro.isFlagSet("save")){
 		std::filesystem::remove_all("src");
 		std::filesystem::remove_all("build");
+		std::filesystem::remove("build.ninja");
+		std::filesystem::remove("Makefile");
 	}
 
 	bro.log.info("Cmds: {}", bro.cmds.size());

--- a/bro.hpp
+++ b/bro.hpp
@@ -489,6 +489,16 @@ inline const std::string_view C_COMPILER_NAME =
 		bool hasLib = false;
 		bool hasApp = false;
 
+		inline void _setup_cmds(){
+			CmdTmpl lib({std::string(flags["ar"]), "rcs", "$out", "$in"});
+			CmdTmpl dll({std::string(flags["ld"]), "$in", "-o", "$out", "-shared"});
+			CmdTmpl exe({std::string(flags["ld"]), "$flags", "$in", "-o", "$out"});
+
+			registerCmd("lib", lib, true);
+			registerCmd("dll", dll, true);
+			registerCmd("exe", exe, true);
+		}
+
 		inline void _setup_default(){
 			std::string header_path = __FILE__;
 			header = File(header_path);
@@ -498,13 +508,7 @@ inline const std::string_view C_COMPILER_NAME =
 			flags["ar"] = "ar";
 			flags["build"] = "build";
 
-			CmdTmpl lib({std::string(flags["ar"]), "rcs", "$out", "$in"});
-			CmdTmpl dll({std::string(flags["ld"]), "$in", "-o", "$out", "-shared"});
-			CmdTmpl exe({std::string(flags["ld"]), "$flags", "$in", "-o", "$out"});
-
-			registerCmd("lib", lib);
-			registerCmd("dll", dll);
-			registerCmd("exe", exe);
+			_setup_cmds();
 		}
 
 		Bro(std::filesystem::path src = __builtin_FILE()):
@@ -601,10 +605,10 @@ inline const std::string_view C_COMPILER_NAME =
 			return flags[name] != "no" && flags[name] != "0";
 		}
 
-		inline bool registerCmd(std::string_view name, const CmdTmpl& cmd){
+		inline bool registerCmd(std::string_view name, const CmdTmpl& cmd, bool force = false){
 			std::string n(name);
 
-			if(cmds.find(n) != cmds.end())
+			if(!force && cmds.find(n) != cmds.end())
 				return true;
 
 			cmds[n] = cmd;

--- a/bro.hpp
+++ b/bro.hpp
@@ -661,7 +661,7 @@ inline const std::string_view C_COMPILER_NAME =
 			std::string m(mod);
 			std::string l(lib);
 
-			if(mods.find(m) == mods.end() || mods.find(l) == mods.end() || mods[l].type != ModType::LIB)
+			if(mods.find(m) == mods.end() || mods.find(l) == mods.end() || (mods[l].type != ModType::LIB && mods[l].type != ModType::STATIC))
 				return true;
 
 			mods[m].deps.insert(l);

--- a/bro.hpp
+++ b/bro.hpp
@@ -455,7 +455,6 @@ inline const std::string_view C_COMPILER_NAME =
 
 	struct Mod{
 		ModType type;
-		std::string name;
 		std::unordered_set<std::string> cmds;
 		std::unordered_set<std::string> deps;
 		std::unordered_set<std::string> flags;
@@ -469,9 +468,9 @@ inline const std::string_view C_COMPILER_NAME =
 		Mod() = default;
 
 		Mod(ModType type, std::string_view name):
-			type{type}, name{name}
+			type{type}
 		{
-			Directory src("src/" + this->name);
+			Directory src("src/" + std::string{name});
 			if(src.exists){
 				dirs.push_back(src);
 			}
@@ -576,7 +575,7 @@ inline const std::string_view C_COMPILER_NAME =
 				cmd.cmd.push_back(exe.path);
 				for(const auto& [name, value]: flags){
 					if(name[0] != '~')
-						cmd.cmd.push_back(std::string(name) + "=" + std::string(value));
+						cmd.cmd.push_back(std::string{name} + "=" + std::string(value));
 				}
 
 				std::exit(cmd.sync(log));

--- a/bro.hpp
+++ b/bro.hpp
@@ -508,6 +508,9 @@ inline const std::string_view C_COMPILER_NAME =
 			flags["ld"] = C_COMPILER_NAME;
 			flags["ar"] = "ar";
 			flags["build"] = "build";
+			flags[".o"] = ".o";
+			flags[".a"] = ".a";
+			flags[".so"] = ".so";
 
 			_setup_cmds();
 		}
@@ -743,7 +746,7 @@ inline const std::string_view C_COMPILER_NAME =
 						std::string ext = file.path.extension();
 						if(!ext.empty()) for(const auto& cmd: mod.cmds){
 							if(cmds[cmd].ext == ext){
-								std::string out = std::string(flags["build"]) + "/obj" + file.path.string().substr(3) + ".o";
+								std::string out = std::string(flags["build"]) + "/obj" + file.path.string().substr(3) + getFlag(".o");
 								mod.objs.push_back(out);
 								if(!(File(out) > file)){
 									mod.needsLinkage = true;
@@ -766,7 +769,7 @@ inline const std::string_view C_COMPILER_NAME =
 						std::string ext = file.path.extension();
 						if(!ext.empty()) for(const auto& cmd: mod.cmds){
 							if(cmds[cmd].ext == ext){
-								std::string out = std::string(flags["build"]) + "/obj/" + name + " files/file_" + std::to_string(index++) + ".o";
+								std::string out = std::string(flags["build"]) + "/obj/" + name + " files/file_" + std::to_string(index++) + getFlag(".o");
 								mod.objs.push_back(out);
 								if(!(File(out) > file)){
 									mod.needsLinkage = true;
@@ -794,7 +797,7 @@ inline const std::string_view C_COMPILER_NAME =
 					continue;
 
 				if(mod.needsLinkage){
-					std::string dot_a = std::string(flags["build"]) + "/lib/lib" + name + ".a";
+					std::string dot_a = std::string(flags["build"]) + "/lib/lib" + name + getFlag(".a");
 					std::filesystem::remove(dot_a);
 					pool.push(cmds["lib"].compile({
 								{"out", {dot_a}},
@@ -803,7 +806,7 @@ inline const std::string_view C_COMPILER_NAME =
 					// TODO: What about .dll?
 					if(mod.type != ModType::STATIC) 
 						pool.push(cmds["dll"].compile({
-								{"out", {std::string(flags["build"]) + "/lib/" + name + ".so"}},
+								{"out", {std::string(flags["build"]) + "/lib/" + name + getFlag(".so")}},
 								{"in", mod.objs}
 							}));
 				}
@@ -823,7 +826,7 @@ inline const std::string_view C_COMPILER_NAME =
 					if(mods[dep].needsLinkage)
 						mod.needsLinkage = true;
 
-					mod.objs.push_back(std::string(flags["build"]) + "/lib/lib" + dep + ".a");
+					mod.objs.push_back(std::string(flags["build"]) + "/lib/lib" + dep + getFlag(".a"));
 				}
 
 				std::vector<std::string> flags(mod.flags.begin(), mod.flags.end());
@@ -849,7 +852,7 @@ inline const std::string_view C_COMPILER_NAME =
 
 				if(mod.needsLinkage){
 					pool.push(cmds["dll"].compile({
-								{"out", {std::string(flags["build"]) + "/app/" + name + ".so"}}, 
+								{"out", {std::string(flags["build"]) + "/app/" + name + getFlag(".so")}}, 
 								{"in", mod.objs}
 							}));
 				}
@@ -893,7 +896,7 @@ inline const std::string_view C_COMPILER_NAME =
 						std::string ext = file.path.extension();
 						if(!ext.empty()) for(const auto& cmd: mod.cmds){
 							if(cmds[cmd].ext == ext){
-								std::string obj = std::string(flags["build"]) + "/obj/" + name + file.path.string() + ".o";
+								std::string obj = std::string(flags["build"]) + "/obj/" + name + file.path.string() + getFlag(".o");
 								mod.objs.push_back(obj);
 								out << "build " << obj << ": " << cmd << " " << file.path.string() << std::endl;
 								out << std::endl;
@@ -909,7 +912,7 @@ inline const std::string_view C_COMPILER_NAME =
 						std::string ext = file.path.extension();
 						if(!ext.empty()) for(const auto& cmd: mod.cmds){
 							if(cmds[cmd].ext == ext){
-								std::string obj = std::string(flags["build"]) + "/obj/" + name + "$ files/file_" + std::to_string(index++) + ".o";
+								std::string obj = std::string(flags["build"]) + "/obj/" + name + "$ files/file_" + std::to_string(index++) + getFlag(".o");
 								mod.objs.push_back(obj);
 								out << "build " << obj << ": " << cmd << " " << file.path.string() << std::endl;
 								out << std::endl;
@@ -930,7 +933,7 @@ inline const std::string_view C_COMPILER_NAME =
 							out << " " << e;
 
 						for(const auto& dep: mod.deps)
-							out << " " << flags["build"] << "/lib/lib" << dep << ".a";
+							out << " " << flags["build"] << "/lib/lib" << dep << getFlag(".a");
 						
 						out << std::endl;
 
@@ -943,26 +946,26 @@ inline const std::string_view C_COMPILER_NAME =
 					} break;
 					case ModType::LIB:
 					{
-						out << "build " << flags["build"] << "/lib/lib" << name << ".a: lib";
+						out << "build " << flags["build"] << "/lib/lib" << name << getFlag(".a") << ": lib";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
 
-						out << "build " << flags["build"] << "/lib/" << name << ".so: dll";
+						out << "build " << flags["build"] << "/lib/" << name << getFlag(".so") << ": dll";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
 					} break;
 					case ModType::STATIC:
 					{
-						out << "build " << flags["build"] << "/lib/lib" << name << ".a: lib";
+						out << "build " << flags["build"] << "/lib/lib" << name << getFlag(".a") << ": lib";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
 					} break;
 					case ModType::APP:
 					{
-						out << "build " << flags["build"] << "/app/" << name << ".so: dll";
+						out << "build " << flags["build"] << "/app/" << name << getFlag(".so") << ": dll";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
@@ -1004,7 +1007,7 @@ inline const std::string_view C_COMPILER_NAME =
 						std::string ext = file.path.extension();
 						if(!ext.empty()) for(const auto& cmd: mod.cmds){
 							if(cmds[cmd].ext == ext){
-								std::string obj = std::string(flags["build"]) + "/obj/" + name + file.path.string() + ".o";
+								std::string obj = std::string(flags["build"]) + "/obj/" + name + file.path.string() + getFlag(".o");
 								mod.objs.push_back(obj);
 								dirs.insert(obj.substr(0, obj.find_last_of('/')));
 								out << obj << ": " << file.path.string() << std::endl;
@@ -1021,7 +1024,7 @@ inline const std::string_view C_COMPILER_NAME =
 						std::string ext = file.path.extension();
 						if(!ext.empty()) for(const auto& cmd: mod.cmds){
 							if(cmds[cmd].ext == ext){
-								std::string obj = std::string(flags["build"]) + "/obj/" + name + "\\\\\\ files/" + file.path.string() + ".o";
+								std::string obj = std::string(flags["build"]) + "/obj/" + name + "\\\\\\ files/" + file.path.string() + getFlag(".o");
 								mod.objs.push_back(obj);
 								dirs.insert(obj.substr(0, obj.find_last_of('/')));
 								out << obj << ": " << file.path.string() << std::endl;
@@ -1046,7 +1049,7 @@ inline const std::string_view C_COMPILER_NAME =
 							out << " " << e;
 
 						for(const auto& dep: mod.deps)
-							out << " " << flags["build"] << "/lib/lib" << dep << ".a";
+							out << " " << flags["build"] << "/lib/lib" << dep << getFlag(".a");
 						
 						out << std::endl;
 
@@ -1059,8 +1062,8 @@ inline const std::string_view C_COMPILER_NAME =
 					} break;
 					case ModType::LIB:
 					{
-						out << name << ": " << flags["build"] << "/lib/lib" << name << ".a " << flags["build"] << "/lib/" << name << ".so" << std::endl;
-						out << flags["build"] << "/lib/lib" << name << ".a:";
+						out << name << ": " << flags["build"] << "/lib/lib" << name << getFlag(".a") << " " << flags["build"] << "/lib/" << name << getFlag(".so") << std::endl;
+						out << flags["build"] << "/lib/lib" << name << getFlag(".a") << ":";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
@@ -1068,7 +1071,7 @@ inline const std::string_view C_COMPILER_NAME =
 						out << "\t" << cmds["lib"].compile({{"in", {"$^"}}, {"out", {"$@"}}}).str() << std::endl;
 						out << std::endl;
 
-						out << flags["build"] << "/lib/" << name << ".so:";
+						out << flags["build"] << "/lib/" << name << getFlag(".so") << ":";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
@@ -1078,8 +1081,8 @@ inline const std::string_view C_COMPILER_NAME =
 					} break;
 					case ModType::STATIC:
 					{
-						out << name << ": " << flags["build"] << "/lib/lib" << name << ".a " << flags["build"] << "/lib/" << name << ".so" << std::endl;
-						out << flags["build"] << "/lib/lib" << name << ".a:";
+						out << name << ": " << flags["build"] << "/lib/lib" << name << getFlag(".a") << std::endl;
+						out << flags["build"] << "/lib/lib" << name << getFlag(".a") << ":";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;
@@ -1089,8 +1092,8 @@ inline const std::string_view C_COMPILER_NAME =
 					} break;
 					case ModType::APP:
 					{
-						out << name << ": " << flags["build"] << "/lib/" << name << ".so" << std::endl;
-						out << flags["build"] << "/app/" << name << ".so:";
+						out << name << ": " << flags["build"] << "/lib/" << name << getFlag(".so") << std::endl;
+						out << flags["build"] << "/app/" << name << getFlag(".so") << ":";
 						for(const auto& e: mod.objs)
 							out << " " << e;
 						out << std::endl;

--- a/bro.hpp
+++ b/bro.hpp
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <array>
 #include <vector>
 #include <future>
 #include <sstream>
@@ -471,19 +472,24 @@ inline const std::string_view C_COMPILER_NAME =
 		std::unordered_map<std::string, Mod> mods;
 		std::unordered_map<std::string_view, std::string_view> flags;
 
+		inline void _setup_default(){
+			flags["cc"] = C_COMPILER_NAME;
+			flags["cxx"] = CXX_COMPILER_NAME;
+			flags["ld"] = C_COMPILER_NAME;
+			flags["ar"] = "ar";
+		}
+
 		Bro(std::filesystem::path src = __builtin_FILE()):
 			src{src}
 		{
-			flags["cc"] = C_COMPILER_NAME;
-			flags["cxx"] = CXX_COMPILER_NAME;
+			_setup_default();
 		}
 		
 		Bro(std::filesystem::path p, std::filesystem::path src = __builtin_FILE()):
 			src{src},
 			exe{p}
 		{
-			flags["cc"] = C_COMPILER_NAME;
-			flags["cxx"] = CXX_COMPILER_NAME;
+			_setup_default();
 		}
 		
 		Bro(int argc, const char** argv, std::filesystem::path src = __builtin_FILE()):
@@ -491,8 +497,7 @@ inline const std::string_view C_COMPILER_NAME =
 			exe{argv[0]},
 			args{argv + 1, argv + argc}
 		{
-			flags["cc"] = C_COMPILER_NAME;
-			flags["cxx"] = CXX_COMPILER_NAME;
+			_setup_default();
 
 			for(size_t i = 0; i < args.size();){
 				auto eq = args[i].find('=');
@@ -602,9 +607,9 @@ inline const std::string_view C_COMPILER_NAME =
 		}
 
 		inline int build(){
-			CmdTmpl lib({"ar", "rcs", "$out", "$in"});
-			CmdTmpl dll({"gcc", "$in", "-o", "$out", "-shared"});
-			CmdTmpl exe({"gcc", "$flags", "$in", "-o", "$out"});
+			CmdTmpl lib({std::string(flags["ar"]), "rcs", "$out", "$in"});
+			CmdTmpl dll({std::string(flags["ld"]), "$in", "-o", "$out", "-shared"});
+			CmdTmpl exe({std::string(flags["ld"]), "$flags", "$in", "-o", "$out"});
 
 			std::filesystem::create_directory("build");
 			std::filesystem::create_directory("build/bin");

--- a/bro.hpp
+++ b/bro.hpp
@@ -466,15 +466,9 @@ inline const std::string_view C_COMPILER_NAME =
 		std::vector<std::string> objs;
 
 		Mod() = default;
-
-		Mod(ModType type, std::string_view name):
+		Mod(ModType type):
 			type{type}
-		{
-			Directory src("src/" + std::string{name});
-			if(src.exists){
-				dirs.push_back(src);
-			}
-		}
+		{}
 	};
 
 	struct Bro{
@@ -631,7 +625,7 @@ inline const std::string_view C_COMPILER_NAME =
 			return registerCmd(name, CmdTmpl{ext, cmd});
 		}
 
-		inline bool registerModule(ModType type, std::string_view name){
+		inline bool registerModule(ModType type, std::string_view name, bool src = true){
 			std::string n(name);
 
 			if(mods.find(n) != mods.end())
@@ -644,8 +638,16 @@ inline const std::string_view C_COMPILER_NAME =
 				case ModType::APP: hasApp = true; break;
 			}
 
-			mods.emplace(n, Mod{type, name});
-			return false;
+			auto [it, ins] = mods.emplace(n, Mod{type});
+
+			if(src){
+				Directory d("src/" + std::string{name});
+				if(d.exists){
+					(*it).second.dirs.push_back(d);
+				}
+			}
+
+			return ins;
 		}
 
 		inline bool use(std::string_view mod, std::string_view cmd){

--- a/bro.hpp
+++ b/bro.hpp
@@ -602,10 +602,9 @@ inline const std::string_view C_COMPILER_NAME =
 		}
 
 		inline int build(){
-			// Get rid of g++ for linkage, use gcc and if someone is willing to use C++ will use link function.
 			CmdTmpl lib({"ar", "rcs", "$out", "$in"});
-			CmdTmpl dll({"g++", "$in", "-o", "$out", "-shared"});
-			CmdTmpl exe({"g++", "$flags", "$in", "-o", "$out"});
+			CmdTmpl dll({"gcc", "$in", "-o", "$out", "-shared"});
+			CmdTmpl exe({"gcc", "$flags", "$in", "-o", "$out"});
 
 			std::filesystem::create_directory("build");
 			std::filesystem::create_directory("build/bin");

--- a/bro.hpp
+++ b/bro.hpp
@@ -534,6 +534,8 @@ inline const std::string_view C_COMPILER_NAME =
 		}
 
 		inline bool isFresh(){
+			if(hasFlag("~FRESH"))
+				return isFlagSet("~FRESH");
 			return !(src > exe || header > exe);
 		}
 
@@ -555,8 +557,11 @@ inline const std::string_view C_COMPILER_NAME =
 				// Run
 				cmd.cmd.clear();
 				cmd.cmd.push_back(exe.path);
-				for(const auto& [name, value]: flags)
-					cmd.cmd.push_back(std::string(name) + "=" + std::string(value));
+				for(const auto& [name, value]: flags){
+					if(name[0] != '~')
+						cmd.cmd.push_back(std::string(name) + "=" + std::string(value));
+				}
+
 				std::exit(cmd.sync(log));
 			}
 		}
@@ -584,7 +589,7 @@ inline const std::string_view C_COMPILER_NAME =
 			if(!hasFlag(name))
 				return dflt;
 
-			return flags[name] != "no" || flags[name] != "0";
+			return flags[name] != "no" && flags[name] != "0";
 		}
 
 		inline bool registerCmd(std::string_view name, const CmdTmpl& cmd){

--- a/bro.hpp
+++ b/bro.hpp
@@ -465,6 +465,7 @@ inline const std::string_view C_COMPILER_NAME =
 
 	struct Bro{
 		Log log;
+		File header;
 		File src;
 		File exe;
 		std::vector<std::string_view> args;
@@ -473,6 +474,8 @@ inline const std::string_view C_COMPILER_NAME =
 		std::unordered_map<std::string_view, std::string_view> flags;
 
 		inline void _setup_default(){
+			std::string header_path = __FILE__;
+			header = File(header_path);
 			flags["cc"] = C_COMPILER_NAME;
 			flags["cxx"] = CXX_COMPILER_NAME;
 			flags["ld"] = C_COMPILER_NAME;
@@ -513,7 +516,7 @@ inline const std::string_view C_COMPILER_NAME =
 		}
 
 		inline bool isFresh(){
-			return !(src > exe);
+			return !(src > exe && header > exe);
 		}
 
 		inline void fresh(){

--- a/bro.hpp
+++ b/bro.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  * 
- * Copyright (c) 2023 YetAnotherFurryMan
+ * Copyright (c) 2023 Damian Satoła
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/bro.hpp
+++ b/bro.hpp
@@ -714,10 +714,13 @@ inline const std::string_view C_COMPILER_NAME =
 					continue;
 
 				if(mod.needsLinkage){
+					std::string dot_a = std::string(flags["build"]) + "/lib/lib" + name + ".a";
+					std::filesystem::remove(dot_a);
 					pool.push(cmds["lib"].compile({
-								{"out", {std::string(flags["build"]) + "/lib/lib" + name + ".a"}},
+								{"out", {dot_a}},
 								{"in", mod.objs}
 							}));
+					// TODO: What about .dll?
 					pool.push(cmds["dll"].compile({
 								{"out", {std::string(flags["build"]) + "/lib/" + name + ".so"}},
 								{"in", mod.objs}
@@ -735,8 +738,12 @@ inline const std::string_view C_COMPILER_NAME =
 				if(mod.type != ModType::EXE)
 					continue;
 
-				for(const auto& dep: mod.deps)
+				for(const auto& dep: mod.deps){
+					if(mods[dep].needsLinkage)
+						mod.needsLinkage = true;
+
 					mod.objs.push_back(std::string(flags["build"]) + "/lib/lib" + dep + ".a");
+				}
 
 				std::vector<std::string> flags(mod.flags.begin(), mod.flags.end());
 


### PR DESCRIPTION
The currently used module-based approach has proved to be painful while working with functional languages (like Haskell or OCaml) and it is unclear how to compile root-file (you pass only one file to the compiler and it searches for the rest) based languages (like Java, Rust, Zig, and so on). Because of that reason I am switching the approach to stage based one.

A stage is a set of commands that can run at the same time. It is transformation based, that means these commands will transform a list of files to other files that may be an input to another stage (like object files or generated source code f.e. YACC output) or a final result (like executables or libraries).

Also I want to add a way to identify the things (stages, commands, modules) by something like UID instead of a runtime name, so it can be saved to an variable and easily compile-time checked reducing frustration.